### PR TITLE
Add missing SVG assets

### DIFF
--- a/public/file.svg
+++ b/public/file.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+  <polyline points="14 2 14 8 20 8"/>
+</svg>

--- a/public/globe.svg
+++ b/public/globe.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <line x1="2" y1="12" x2="22" y2="12"/>
+  <line x1="12" y1="2" x2="12" y2="22"/>
+</svg>

--- a/public/next.svg
+++ b/public/next.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="32" viewBox="0 0 100 32">
+  <text x="0" y="24" font-family="sans-serif" font-size="24">Next.js</text>
+</svg>

--- a/public/vercel.svg
+++ b/public/vercel.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="75" height="65" viewBox="0 0 75 65">
+  <polygon points="37.5,0 75,65 0,65" fill="black"/>
+</svg>

--- a/public/window.svg
+++ b/public/window.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+  <line x1="3" y1="9" x2="21" y2="9"/>
+</svg>


### PR DESCRIPTION
## Summary
- add placeholder `next.svg`, `vercel.svg`, `file.svg`, `window.svg`, and `globe.svg`

## Testing
- `npm run build` *(fails: `next` not found)*