### PR TITLE
Pin next and react versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "carmichael",
       "version": "0.1.0",
       "dependencies": {
-        "next": "latest",
-        "react": "latest",
-        "react-dom": "latest"
+        "next": "13.x",
+        "react": "18.x",
+        "react-dom": "18.x"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
-    "react": "latest",
-    "react-dom": "latest"
+    "next": "13.x",
+    "react": "18.x",
+    "react-dom": "18.x"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.7",


### PR DESCRIPTION
## Summary
- pin `next`, `react`, and `react-dom` versions in `package.json`
- sync the dependency ranges in `package-lock.json`

## Testing
- `npm install --package-lock-only --no-audit --no-fund --silent` *(fails: no output)*