### PR TITLE
Add marquee logos section

### DIFF
--- a/public/logos/bmw.svg
+++ b/public/logos/bmw.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#2e2e2e"/>
+  <text x="60" y="35" font-size="28" text-anchor="middle" fill="white" font-family="Arial">BMW</text>
+</svg>

--- a/public/logos/ford.svg
+++ b/public/logos/ford.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#003399"/>
+  <text x="60" y="35" font-size="28" text-anchor="middle" fill="white" font-family="Arial">Ford</text>
+</svg>

--- a/public/logos/honda.svg
+++ b/public/logos/honda.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect width="120" height="60" rx="8" fill="#c3002f"/>
+  <text x="60" y="35" font-size="28" text-anchor="middle" fill="white" font-family="Arial">Honda</text>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,16 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes marquee {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
+.animate-marquee {
+  animation: marquee 20s linear infinite;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,13 @@ import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import CategoryGrid from "@/components/CategoryGrid";
 import Footer from "@/components/Footer";
+import Image from "next/image";
+
+const logos = [
+  { src: "/logos/ford.svg", alt: "Ford" },
+  { src: "/logos/bmw.svg", alt: "BMW" },
+  { src: "/logos/honda.svg", alt: "Honda" },
+];
 
 export default function Home() {
   return (
@@ -10,6 +17,19 @@ export default function Home() {
       <main className="flex flex-1 flex-col">
         <Hero />
         <CategoryGrid />
+        <section className="overflow-hidden py-8">
+          <div className="flex gap-12 animate-marquee" aria-label="Brand logos">
+            {logos.map((logo) => (
+              <Image
+                key={logo.src}
+                src={logo.src}
+                alt={logo.alt}
+                width={120}
+                height={60}
+              />
+            ))}
+          </div>
+        </section>
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- display car brand logos scrolling below the category grid
- provide placeholder SVG logos
- animate logos with a simple marquee animation

## Testing
- `npm install` *(fails: Exit handler never called)*