### PR TITLE
Remove experimental appDir option

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,18 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // Enable React Strict Mode for highlighting potential problems
+  /* React strict mode is on by default in 14.x, but keep it if you like */
   reactStrictMode: true,
 
-  // Configure remote image domains and formats
   images: {
     domains: ["example.com"],
     formats: ["image/webp"],
-  },
-
-  // Opt in to experimental features
-  experimental: {
-    appDir: true,
   },
 };
 


### PR DESCRIPTION
## Summary
- remove the experimental `appDir` block from `next.config.ts`

## Testing
- `npm test` *(fails: `jest` not found)*