### PR TITLE
Fix Tailwind plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can start editing the main page by modifying `src/app/page.tsx`. The page au
 
 ## Styling
 
-Styles are built with Tailwind CSS and processed by PostCSS. The [`postcss.config.js`](./postcss.config.js) file loads the `@tailwindcss/postcss` plugin along with `autoprefixer`, so vendor prefixes are automatically applied where needed.
+Styles are built with Tailwind CSS and processed by PostCSS. The [`postcss.config.js`](./postcss.config.js) file loads the `tailwindcss` plugin along with `autoprefixer`, so vendor prefixes are automatically applied where needed.
 
 ## Learn More
 

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    'tailwindcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- switch the plugin key in `postcss.config.js` from `@tailwindcss/postcss` to `tailwindcss`
- update README wording to mention the `tailwindcss` plugin

## Testing
- `npm test` *(fails: jest not found)*